### PR TITLE
Window scroll to

### DIFF
--- a/lib/karen.coffee
+++ b/lib/karen.coffee
@@ -187,6 +187,16 @@ class MockWindow extends MockElement
 
   Date: MockDate
 
+  scrollTo: (x, y) ->
+    @pageXOffset = x
+    @pageYOffset = y
+
+    @document.documentElement.scrollLeft = x
+    @document.documentElement.scrollTop = y
+
+    @document.body.scrollLeft = x
+    @document.body.scrollTop = y
+
   pageXOffset: 0
   pageYOffset: 0
 

--- a/lib/karen.coffee
+++ b/lib/karen.coffee
@@ -97,10 +97,10 @@ class MockNode extends MockElement
   getBoundingClientRect: ->
     height: 0
     width: 0
-    left: 0
     bottom: 0
     right: 0
-    top: 0
+    left: -@ownerDocument.defaultView.pageXOffset
+    top: -@ownerDocument.defaultView.pageYOffset
 
   scrollTop: 0
   scrollLeft: 0

--- a/lib/karen.coffee
+++ b/lib/karen.coffee
@@ -16,6 +16,9 @@ class Evented
     unless index == -1
       @listeners[event].splice(index, 1)
 
+class MockEvent
+  constructor: (@type) ->
+
 class MockDate
   constructor: (args...) ->
     if args.length == 0
@@ -197,6 +200,8 @@ class MockWindow extends MockElement
     @document.body.scrollLeft = x
     @document.body.scrollTop = y
 
+    @emit 'scroll', new MockEvent('scroll')
+
   pageXOffset: 0
   pageYOffset: 0
 
@@ -308,6 +313,7 @@ api = {
   MockNavigator
   MockScreen
   MockDate
+  MockEvent
 }
 
 if module?

--- a/test/mock_event.spec.coffee
+++ b/test/mock_event.spec.coffee
@@ -1,0 +1,8 @@
+{MockEvent} = require('../lib/karen')
+
+describe 'MockEvent', ->
+  def 'event', -> new MockEvent('event')
+
+  describe '#type', ->
+    it 'returns the event type', ->
+      expect(@event.type).to.equal('event')

--- a/test/mock_node.spec.coffee
+++ b/test/mock_node.spec.coffee
@@ -42,27 +42,27 @@ describe 'MockNode', ->
       @boundingClientRect = @node.getBoundingClientRect()
 
     describe '#height', ->
-      it 'returns node height', ->
+      it 'is zero by default', ->
         @boundingClientRect.height.should.equal(0)
 
     describe '#width', ->
-      it 'returns node width', ->
+      it 'is zero by default', ->
         @boundingClientRect.width.should.equal(0)
 
     describe '#left', ->
-      it 'returns node left', ->
+      it 'is zero by default', ->
         @boundingClientRect.left.should.equal(0)
 
     describe '#bottom', ->
-      it 'returns node bottom', ->
+      it 'is zero by default', ->
         @boundingClientRect.bottom.should.equal(0)
 
     describe '#right', ->
-      it 'returns node right', ->
+      it 'is zero by default', ->
         @boundingClientRect.right.should.equal(0)
 
     describe '#top', ->
-      it 'returns node top', ->
+      it 'is zero by default', ->
         @boundingClientRect.top.should.equal(0)
 
   describe '#scrollTop', ->

--- a/test/mock_node.spec.coffee
+++ b/test/mock_node.spec.coffee
@@ -2,6 +2,7 @@
 
 describe 'MockNode', ->
   def 'node', -> new MockNode
+  def 'window', -> @node.ownerDocument.defaultView
 
   describe '#style', ->
     it 'allows for read/write styles', ->
@@ -50,8 +51,10 @@ describe 'MockNode', ->
         @boundingClientRect.width.should.equal(0)
 
     describe '#left', ->
-      it 'is zero by default', ->
-        @boundingClientRect.left.should.equal(0)
+      it 'is based on the window left scroll', ->
+        @node.getBoundingClientRect().left.should.equal(0)
+        @window.scrollTo(100, 0)
+        @node.getBoundingClientRect().left.should.equal(-100)
 
     describe '#bottom', ->
       it 'is zero by default', ->
@@ -62,8 +65,10 @@ describe 'MockNode', ->
         @boundingClientRect.right.should.equal(0)
 
     describe '#top', ->
-      it 'is zero by default', ->
-        @boundingClientRect.top.should.equal(0)
+      it 'is based on the window top scroll', ->
+        @node.getBoundingClientRect().top.should.equal(0)
+        @window.scrollTo(0, 100)
+        @node.getBoundingClientRect().top.should.equal(-100)
 
   describe '#scrollTop', ->
     it 'returns scroll top', ->

--- a/test/mock_window.spec.coffee
+++ b/test/mock_window.spec.coffee
@@ -335,3 +335,19 @@ describe 'MockWindow', ->
         expect(bar).to.equal('bar')
         done()
       , 'foo', 'bar'
+
+  describe '#scrollTo', ->
+    it 'updates viewport positions', ->
+      @window.pageXOffset = 0
+      @window.pageYOffset = 0
+      @window.document.documentElement.scrollLeft = 0
+      @window.document.documentElement.scrollTop = 0
+      @window.document.body.scrollLeft = 0
+      @window.document.body.scrollTop = 0
+      @window.scrollTo(100, 200)
+      expect(@window.pageXOffset).to.equal(100)
+      expect(@window.pageYOffset).to.equal(200)
+      expect(@window.document.documentElement.scrollLeft).to.equal(100)
+      expect(@window.document.documentElement.scrollTop).to.equal(200)
+      expect(@window.document.body.scrollLeft).to.equal(100)
+      expect(@window.document.body.scrollTop).to.equal(200)

--- a/test/mock_window.spec.coffee
+++ b/test/mock_window.spec.coffee
@@ -351,3 +351,12 @@ describe 'MockWindow', ->
       expect(@window.document.documentElement.scrollTop).to.equal(200)
       expect(@window.document.body.scrollLeft).to.equal(100)
       expect(@window.document.body.scrollTop).to.equal(200)
+
+    it 'fires scroll event', (done) ->
+      @window.on 'scroll', (event) =>
+        expect(event.type).to.equal('scroll')
+        expect(@window.pageXOffset).to.equal(100)
+        expect(@window.pageYOffset).to.equal(200)
+        done()
+      @window.scrollTo(100, 200)
+


### PR DESCRIPTION
Add `MockWindow#scrollTo` function. Also adjust `MockNode#getBoundingClientRect` to include the viewport offsets.
