### PR TITLE
Update implementation of MockWindow#setImmediate

### DIFF
--- a/lib/karen.coffee
+++ b/lib/karen.coffee
@@ -299,7 +299,7 @@ class MockWindow extends MockElement
     @tick(ms, callback)
 
   setImmediate: (callback, params...) ->
-    setImmediate(callback, params...)
+    callback(params...)
 
 api = {
   Evented

--- a/test/mock_window.spec.coffee
+++ b/test/mock_window.spec.coffee
@@ -329,7 +329,7 @@ describe 'MockWindow', ->
       @window.tickAsync(50, done)
 
   describe '#setImmediate', ->
-    it 'callbacks', (done) ->
+    it 'callbacks on next event loop run', (done) ->
       @window.setImmediate (foo, bar) ->
         expect(foo).to.equal('foo')
         expect(bar).to.equal('bar')


### PR DESCRIPTION
First of all, this never should have used the internal Node setImmediate function, not sure why that was decided.

The new implementation will not behave exactly as setImmediate does in Node and the browser. The difference is that with this implementation, immediate callbacks are not guaranteed to run before timeouts and interval callbacks.

The reason why we choosed this implementation is that otherwise the user of this library would have to tick to make the immediate callback run. We decided against this for simplicity.
