### PR TITLE
Add .tagName 

### DIFF
--- a/lib/karen.coffee
+++ b/lib/karen.coffee
@@ -45,7 +45,11 @@ class MockScreen
 class MockElement extends Evented
   constructor: (@type) ->
     super()
-    @__defineGetter__ 'tagName', -> @type.toUpperCase()
+    @__defineGetter__ 'tagName', ->
+      if @type
+        @type.toUpperCase()
+      else
+        undefined
 
   define: (name, callback) ->
     cache = @cache ?= {}

--- a/lib/karen.coffee
+++ b/lib/karen.coffee
@@ -45,7 +45,7 @@ class MockScreen
 class MockElement extends Evented
   constructor: (@type) ->
     super()
-    @__defineGetter__ 'tagName', -> @type
+    @__defineGetter__ 'tagName', -> @type.toUpperCase()
 
   define: (name, callback) ->
     cache = @cache ?= {}

--- a/lib/karen.coffee
+++ b/lib/karen.coffee
@@ -45,6 +45,7 @@ class MockScreen
 class MockElement extends Evented
   constructor: (@type) ->
     super()
+    @__defineGetter__ 'tagName', -> @type
 
   define: (name, callback) ->
     cache = @cache ?= {}

--- a/test/mock_element.spec.coffee
+++ b/test/mock_element.spec.coffee
@@ -1,7 +1,7 @@
 {MockElement} = require('../lib/karen')
 
 describe 'MockElement', ->
-  def 'element', -> new MockElement('IMG')
+  def 'element', -> new MockElement('img')
 
   describe '#new', ->
     it 'sets tagName', ->

--- a/test/mock_element.spec.coffee
+++ b/test/mock_element.spec.coffee
@@ -1,7 +1,11 @@
 {MockElement} = require('../lib/karen')
 
 describe 'MockElement', ->
-  def 'element', -> new MockElement
+  def 'element', -> new MockElement('IMG')
+
+  describe '#new', ->
+    it 'sets tagName', ->
+      @element.tagName.should.eq('IMG')
 
   describe '#addEventListener', ->
     it 'callbacks on event', (done) ->

--- a/test/mock_element.spec.coffee
+++ b/test/mock_element.spec.coffee
@@ -7,6 +7,9 @@ describe 'MockElement', ->
     it 'sets tagName', ->
       @element.tagName.should.eq('IMG')
 
+    it 'returns undefined if no tag', ->
+      expect(new MockElement().tagName).to.eq(undefined)
+
   describe '#addEventListener', ->
     it 'callbacks on event', (done) ->
       @element.addEventListener('event', done)


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName

Because we want to implement `getElementsByTagName` properly in upcoming PR. Part of burtcorp/agency#691.